### PR TITLE
Slight changes to README instructions for setting up Redis via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ npm install
 pnpm install
 ```
 
-Install Database via Docker (REDIS):
+Install and Run Redis via Docker in the background:
 
 ```bash
-docker run -p 6379:6379 -it redis/redis-stack-server:latest
+docker run --name redis -d -p 6379:6379 redis/redis-stack-server:latest
 ```
 
-Load the database:
+Run database migrations:
 
 ```bash
 node migration/migrate.js
@@ -35,4 +35,12 @@ Start the development server on http://localhost:3000
 
 ```bash
 npm run dev -- -o
+```
+
+## Stopping Redis
+
+Stop REDIS if you'd like:
+
+```bash
+docker container stop redis
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run dev -- -o
 
 ## Stopping Redis
 
-Stop REDIS if you'd like:
+Stop Redis if you'd like:
 
 ```bash
 docker container stop redis

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Install and Run Redis via Docker in the background:
 docker run --name redis -d -p 6379:6379 redis/redis-stack-server:latest
 ```
 
+You can then run Redis in the future with:
+
+```bash
+docker container start redis
+```
+
 Run database migrations:
 
 ```bash


### PR DESCRIPTION
This updates instructions so that redis runs daemonized (`-d`, no `-it`) so you don't need multiple terminals to run.

Also added instructions for "stopping" redis.